### PR TITLE
Remove check that is always false

### DIFF
--- a/global-cluster-utils.sh
+++ b/global-cluster-utils.sh
@@ -2,10 +2,6 @@
 
 for_each_cluster() {
     CLUSTER_STATE_URI=${CLUSTER_STATE_URI:-gs://sixty-sre-cluster-state/clusters}
-    if [ -z "$CLUSTER_STATE_URI" ];then
-        echo "error: CLUSTER_STATE_URI is not set"
-        exit 1
-    fi
 
     if [ -z "$DEPLOYMENT_CREDENTIALS" ];then
         echo "error: DEPLOYMENT_CREDENTIALS is not set to b64 encoded service account"


### PR DESCRIPTION
`CLUSTER_STATE_URI` is set to default value in the first line of this function, there is no need to check if it is not set because this will never happen.